### PR TITLE
Made tensor_smooth reparam the new default

### DIFF
--- a/src/mssm/src/python/terms.py
+++ b/src/mssm/src/python/terms.py
@@ -283,8 +283,9 @@ class f(GammTerm):
         when relying on the ``qEFS`` update to estimate smoothing penalty parameters, performance
         drops drastically for tensor smooth terms when **not** relying on the parameterization by
         Wood (2006). Hence, it is reccomended that you set ``rp=2`` for tensor smooths when relying
-        on this update. Defaults to 0, meaning no re-parameterization.
-    :type rp: int, optional
+        on this update. Defaults to ``None`` which means it will be set to 0 for univariate smooth
+        terms (meaning no re-parameterization) and 2 for tensor smooths.
+    :type rp: int | None, optional
     :param constraint: What kind of identifiability constraints should be absorbed by the terms (if
         they are to be identifiable). Either QR-based constraints (default, well-behaved), by means
         of column-dropping (no infill, not so well-behaved), or by means of difference re-coding
@@ -298,7 +299,7 @@ class f(GammTerm):
     :param scale_te: Whether or not the penalty matrices of marginal smooths should be scaled
         by their largest eigenvalue. This can improve numerical stability and is thus reccomended
         when relying on the ``qEFS`` update to estimate smoothing penalty parameters.
-        Set to False by default.
+        Set to True by default.
     :type scale_te: bool, optional
     :param basis: The basis functions to use to construct the spline matrix. By default a B-spline
         basis (Eilers & Marx, 2010) implemented in :func:`mssm.src.smooths.B_spline_basis`.
@@ -336,10 +337,10 @@ class f(GammTerm):
         id: int | None = None,
         nk: int | list[int] = None,
         te: bool = False,
-        rp: int = 0,
+        rp: int | None = None,
         constraint: ConstType = ConstType.QR,
         identifiable: bool = True,
-        scale_te: bool = False,
+        scale_te: bool = True,
         basis: Callable = smooths.B_spline_basis,
         basis_kwargs: dict = {},
         is_penalized: bool = True,
@@ -358,6 +359,13 @@ class f(GammTerm):
                     "``variables``."
                 )
             )
+
+        # Handle default re-parameterization assignment.
+        if rp is None:
+            if len(variables) == 1:
+                rp = 0
+            else:
+                rp = 2
 
         if rp != 0 and penalty is not None and (len(penalty) > len(variables)):
             raise ValueError(

--- a/tests/test_fast.py
+++ b/tests/test_fast.py
@@ -86,7 +86,7 @@ class Test_GAM_TE:
         terms=[
             i(),  # The intercept, a
             l(["cond"]),  # Offset for cond='b'
-            f(["time", "x"], by="cond", te=True, nk=9),
+            f(["time", "x"], by="cond", te=True, nk=9, rp=0, scale_te=False),
         ],  # one smooth surface over time and x - f(time,x) - per level of cond: three-way interaction!
         data=dat,
         print_warn=False,
@@ -149,9 +149,9 @@ class Test_GAM_TE_BINARY:
         terms=[
             i(),  # The intercept, a
             f(
-                ["time", "x"], te=True, nk=9
+                ["time", "x"], te=True, nk=9, rp=0, scale_te=False
             ),  # one smooth surface over time and x - f(time,x) - for the reference level = cond == b
-            f(["time", "x"], te=True, binary=["cond", "a"], nk=9),
+            f(["time", "x"], te=True, binary=["cond", "a"], nk=9, rp=0, scale_te=False),
         ],  # another smooth surface over time and x - f(time,x) - representing the difference from the other surface when cond==a
         data=dat,
         print_warn=False,
@@ -375,7 +375,12 @@ class Test_GAMM:
                 ["x"], by="cond", constraint=ConstType.QR
             ),  # to-way interaction between x and cond; one smooth over x per cond level
             f(
-                ["time", "x"], by="cond", constraint=ConstType.QR, nk=9
+                ["time", "x"],
+                by="cond",
+                constraint=ConstType.QR,
+                nk=9,
+                rp=0,
+                scale_te=False,
             ),  # three-way interaction
             fs(["time"], rf="sub"),
         ],  # Random non-linear effect of time - one smooth per level of factor sub
@@ -1332,8 +1337,6 @@ class Test_te_scaling_qefs:
                 te=True,
                 penalty=[DifferencePenalty()],
                 pen_kwargs=[{"m": 2}],
-                rp=2,
-                scale_te=True,
             ),
         ],
         data=sim_dat,

--- a/tests/test_gamm.py
+++ b/tests/test_gamm.py
@@ -94,7 +94,9 @@ class Test_BIG_GAMM_Discretize:
             f(
                 ["x"], by="cond"
             ),  # to-way interaction between x and cond; one smooth over x per cond level
-            f(["time", "x"], by="cond", nk=9),  # three-way interaction
+            f(
+                ["time", "x"], by="cond", nk=9, rp=0, scale_te=False
+            ),  # three-way interaction
             fs(["time"], rf="series", nk=20, approx_deriv=discretize),
         ],  # Random non-linear effect of time - one smooth per level of factor series
         data=dat,
@@ -147,6 +149,8 @@ class Test_NUll_penalty_reparam:
                 constraint=ConstType.QR,
                 penalize_null=True,
                 nk=9,
+                rp=0,
+                scale_te=False,
             ),  # three-way interaction
             fs(["time"], rf="sub"),
         ],  # Random non-linear effect of time - one smooth per level of factor sub
@@ -258,6 +262,8 @@ class Test_NUll_1:
                 constraint=ConstType.QR,
                 penalize_null=True,
                 nk=9,
+                rp=0,
+                scale_te=False,
             ),  # three-way interaction
             fs(["time"], rf="sub"),
         ],  # Random non-linear effect of time - one smooth per level of factor sub
@@ -313,6 +319,8 @@ class Test_NUll_2:
                 penalize_null=True,
                 id=1,
                 nk=9,
+                rp=0,
+                scale_te=False,
             ),  # three-way interaction
             fs(["time"], rf="sub"),
         ],  # Random non-linear effect of time - one smooth per level of factor sub
@@ -387,6 +395,8 @@ class Test_NUll_3:
                 constraint=ConstType.QR,
                 penalize_null=True,
                 nk=9,
+                rp=0,
+                scale_te=False,
             ),  # three-way interaction
             fs(["time"], rf="sub"),
         ],  # Random non-linear effect of time - one smooth per level of factor sub
@@ -462,6 +472,8 @@ class Test_NUll_4:
                 penalize_null=True,
                 id=1,
                 nk=9,
+                rp=0,
+                scale_te=False,
             ),  # three-way interaction
             fs(["time"], rf="sub"),
         ],  # Random non-linear effect of time - one smooth per level of factor sub
@@ -505,7 +517,12 @@ class Test_ar1_Gaussian:
             l(["cond"]),
             f(["time"], by="cond"),
             f(["x"], by="cond"),
-            f(["time", "x"], by="cond"),
+            f(
+                ["time", "x"],
+                by="cond",
+                rp=0,
+                scale_te=False,
+            ),
         ],
         data=dat,
         print_warn=False,
@@ -1508,7 +1525,12 @@ class Test_BIG_GAMM:
                 ["x"], by="cond", constraint=ConstType.QR
             ),  # to-way interaction between x and cond; one smooth over x per cond level
             f(
-                ["time", "x"], by="cond", constraint=ConstType.QR, nk=9
+                ["time", "x"],
+                by="cond",
+                constraint=ConstType.QR,
+                nk=9,
+                rp=0,
+                scale_te=False,
             ),  # three-way interaction
             fs(["time"], rf="sub"),
         ],  # Random non-linear effect of time - one smooth per level of factor sub
@@ -1573,7 +1595,12 @@ class Test_BIG_GAMM_keep_cov:
                 ["x"], by="cond", constraint=ConstType.QR
             ),  # to-way interaction between x and cond; one smooth over x per cond level
             f(
-                ["time", "x"], by="cond", constraint=ConstType.QR, nk=9
+                ["time", "x"],
+                by="cond",
+                constraint=ConstType.QR,
+                nk=9,
+                rp=0,
+                scale_te=False,
             ),  # three-way interaction
             fs(["time"], rf="sub"),
         ],  # Random non-linear effect of time - one smooth per level of factor sub
@@ -1909,7 +1936,7 @@ class Test_te_rs_fact:
         lhs("y"),
         [
             i(),
-            f(["time", "x"], te=True, nk=5),
+            f(["time", "x"], te=True, nk=5, rp=0, scale_te=False),
             rs(["fact", "sub"]),
             rs(["x", "sub"], by="fact"),
         ],
@@ -2129,7 +2156,7 @@ class Test_te_rs_fact_QR:
         lhs("y"),
         [
             i(),
-            f(["time", "x"], te=True, nk=5),
+            f(["time", "x"], te=True, nk=5, rp=0, scale_te=False),
             rs(["fact", "sub"]),
             rs(["x", "sub"], by="fact"),
         ],
@@ -2342,7 +2369,7 @@ class Test_print_parametric:
         [
             i(),
             l(["fact"]),
-            f(["time", "x"], te=True, nk=5),
+            f(["time", "x"], te=True, nk=5, rp=0, scale_te=False),
             rs(["fact", "sub"]),
             rs(["x", "sub"], by="fact"),
         ],
@@ -2378,7 +2405,7 @@ class Test_ti_rs_fact:
             i(),
             f(["x"]),
             f(["time"]),
-            f(["time", "x"], te=False, nk=5),
+            f(["time", "x"], te=False, nk=5, rp=0, scale_te=False),
             rs(["fact", "sub"]),
             rs(["x", "sub"], by="fact"),
         ],
@@ -2771,7 +2798,12 @@ class Test_te_p_values:
 
     formula = Formula(
         lhs("y"),
-        [i(), f(["x0", "x3"], te=True, nk=9), f(["x1"]), f(["x2"])],
+        [
+            i(),
+            f(["x0", "x3"], te=True, nk=9, rp=0, scale_te=False),
+            f(["x1"]),
+            f(["x2"]),
+        ],
         data=sim_dat,
     )
     model = GAMM(formula, Gaussian())

--- a/tests/test_gammlss.py
+++ b/tests/test_gammlss.py
@@ -559,7 +559,9 @@ class Test_te_p_values:
     sim_dat = sim3(n=500, scale=2, c=0, seed=20)
 
     formula_m = Formula(
-        lhs("y"), [i(), f(["x0", "x3"], te=True, nk=9), f(["x1"])], data=sim_dat
+        lhs("y"),
+        [i(), f(["x0", "x3"], te=True, nk=9, rp=0, scale_te=False), f(["x1"])],
+        data=sim_dat,
     )
 
     formula_sd = Formula(lhs("y"), [i(), f(["x0"]), f(["x2"])], data=sim_dat)


### PR DESCRIPTION
**Overview**:

Release 1.1.2 introduced the tensor smooth basis and penalty construction method of Wood, S. N. (2006).  This PR enables these by default for tensor smooths.

I.e., defining

```
sim_dat = sim15(500, 2)
sim_formula_m = Formula(
    lhs("y"),
    [
        I(),
        f(["x1", "x2"], te=True),
    ],
    data=sim_dat,
)
```

is now equivalent to defining

```
sim_dat = sim15(500, 2)
sim_formula_m = Formula(
    lhs("y"),
    [
        I(),
        f(["x1", "x2"], te=True, rp=2, scale_te=True),
    ],
    data=sim_dat,
)
```

Before this PR we had ``rp=0`` and  ``scale_te=False`` by default. Univariate smooth terms are not affected.
