### PR TITLE
Speed up Prop. Hazard model estimation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -36,7 +36,7 @@ jobs:
           run: |
                 sphinx-build docs docs/_build
         - name: Upload artifact
-          uses: actions/upload-pages-artifact@v3
+          uses: actions/upload-pages-artifact@v5
           with:
             path: './docs/_build'
         - name: Deploy to GitHub Pages

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -115,7 +115,7 @@ jobs:
           pip install pytest pytest-cov mssmViz==0.1.51 numdifftools arviz>=0.23.0
           pytest ./tests/test_fast.py ./tests/test_gamm.py ./tests/test_gammlss.py ./tests/test_gsmm.py ./tests/test_compare.py ./tests/test_hsmm.py --cov=mssm --cov-report=xml --cov-report=html
       - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         

--- a/setup.py
+++ b/setup.py
@@ -75,4 +75,11 @@ ext5 = Pybind11Extension(
     cxx_std=14,
 )
 
-setup(ext_modules=[ext1, ext2, ext3, ext4, ext5])
+ext6 = Pybind11Extension(
+    name="hazard",
+    sources=["src/mssm/src/cpp/hazard.cpp"],
+    include_dirs=[get_eigen_include()],
+    cxx_std=14,
+)
+
+setup(ext_modules=[ext1, ext2, ext3, ext4, ext5, ext6])

--- a/src/mssm/src/cpp/hazard.cpp
+++ b/src/mssm/src/cpp/hazard.cpp
@@ -1,0 +1,178 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+#include<Eigen/Sparse>
+#include <Eigen/Dense>
+#include <iostream>
+#include <vector>
+#include <memory>
+#include <cmath>
+#include <limits>
+
+namespace py = pybind11;
+typedef Eigen::Vector<long long int, Eigen::Dynamic> VectorXi64;
+
+double llk2(
+        size_t nt,
+        const Eigen::Ref<Eigen::VectorXd>& gamma,
+        const Eigen::Ref<VectorXi64>& delta,
+        py::list ris
+    )
+    {
+        /*
+        - nt is number of unique event times.
+        - gamma is np.exp(eta)
+        - delta are censoring indices.
+        - ris holds index vectors as described by WPS (2016), holding for each unique end time
+        the indices to the corresponding rows in model matrix ``X``
+
+        Computations from: Wood, S. N., Pya, N., Saefken, B., (2016). Smoothing Parameter and
+        Model Selection for General Smooth Models
+        */
+
+        double gamma_p = 0.0;
+        double allk = 0.0;
+        for (size_t j = 0; j < nt; j++)
+        {
+            // Get ri[j] as matrix, then array
+            py::handle ri_jh = ris[j];
+            py::array_t<long long int> ri_j = py::cast<py::array>(ri_jh);
+            py::buffer_info info_j = ri_j.request();
+
+            long long int *ptr_j = static_cast<long long int *>(info_j.ptr);
+
+            Eigen::Map<VectorXi64> rij(ptr_j,ri_j.shape(0),1);
+            
+            // Now compute llk adjustment for ri[j]
+            double dj = delta(rij.array()).array().sum();
+
+            // Adjust gamma_p
+            gamma_p += gamma(rij.array()).array().sum();
+
+            allk -= dj * log(gamma_p);
+        }
+        
+        return allk;
+    }
+
+Eigen::VectorXd grad2(
+        size_t nt,
+        const Eigen::Ref<Eigen::VectorXd>& gamma,
+        const Eigen::Ref<VectorXi64>& delta,
+        py::list ris,
+        const Eigen::Ref<Eigen::MatrixXd,0,Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> &X
+    )
+    {
+        /*
+        - nt is number of unique event times.
+        - gamma is np.exp(eta)
+        - delta are censoring indices.
+        - ris holds index vectors as described by WPS (2016), holding for each unique end time
+        the indices to the corresponding rows in ``X``
+        - X is model matrix
+
+        Computations from: Wood, S. N., Pya, N., Saefken, B., (2016). Smoothing Parameter and
+        Model Selection for General Smooth Models
+        */
+
+        size_t n_coef = X.cols();
+        Eigen::VectorXd grad2;
+        grad2.setZero(n_coef);
+
+        double gamma_p = 0.0;
+        Eigen::VectorXd bp;
+        bp.setZero(n_coef);
+        for (size_t j = 0; j < nt; j++)
+        {
+            // Get ri[j] as matrix, then array
+            py::handle ri_jh = ris[j];
+            py::array_t<long long int> ri_j = py::cast<py::array>(ri_jh);
+            py::buffer_info info_j = ri_j.request();
+
+            long long int *ptr_j = static_cast<long long int *>(info_j.ptr);
+
+            Eigen::Map<VectorXi64> rij(ptr_j,ri_j.shape(0),1);
+            
+            // Now compute llk adjustment for ri[j]
+            double dj = delta(rij.array()).array().sum();
+
+            // Adjust gamma_p
+            gamma_p += gamma(rij.array()).array().sum();
+
+            // Now gradient computations
+            bp += (gamma(rij.array()).transpose() * X(rij.array(),Eigen::all)).transpose();
+
+            grad2 -= (dj * (bp / gamma_p));
+        }
+        
+        return grad2;
+    }
+
+Eigen::MatrixXd hessian(
+        size_t nt,
+        const Eigen::Ref<Eigen::VectorXd>& gamma,
+        const Eigen::Ref<VectorXi64>& delta,
+        py::list ris,
+        const Eigen::Ref<Eigen::MatrixXd,0,Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> &X
+    )
+    {
+        /*
+        - nt is number of unique event times.
+        - gamma is np.exp(eta)
+        - delta are censoring indices.
+        - ris holds index vectors as described by WPS (2016), holding for each unique end time
+        the indices to the corresponding rows in ``X``
+        - X is model matrix
+
+        Computations from: Wood, S. N., Pya, N., Saefken, B., (2016). Smoothing Parameter and
+        Model Selection for General Smooth Models
+        */
+
+        size_t n_coef = X.cols();
+        Eigen::MatrixXd hess;
+        hess.setZero(n_coef,n_coef);
+        Eigen::MatrixXd Ap;
+        Ap.setZero(n_coef,n_coef);
+
+        double gamma_p = 0.0;
+        Eigen::VectorXd bp;
+        bp.setZero(n_coef);
+        for (size_t j = 0; j < nt; j++)
+        {
+            // Get ri[j] as matrix, then array
+            py::handle ri_jh = ris[j];
+            py::array_t<long long int> ri_j = py::cast<py::array>(ri_jh);
+            py::buffer_info info_j = ri_j.request();
+
+            long long int *ptr_j = static_cast<long long int *>(info_j.ptr);
+
+            Eigen::Map<VectorXi64> rij(ptr_j,ri_j.shape(0),1);
+            
+            // Now compute llk adjustment for ri[j]
+            double dj = delta(rij.array()).array().sum();
+
+            // Adjust gamma_p
+            Eigen::VectorXd gi = gamma(rij.array());
+            gamma_p += gi.array().sum();
+
+            // Now gradient related computations
+            Eigen::MatrixXd Xi = X(rij.array(),Eigen::all);
+            bp += (gi.transpose() * Xi).transpose();
+
+            // And now hessian related computations
+            Eigen::MatrixXd Ai = (gi.asDiagonal() * Xi).transpose() * Xi;
+            Ap += Ai;
+
+            hess += (dj * bp * bp.transpose() / pow(gamma_p,2) - dj * Ap / gamma_p);
+
+        }
+        
+        return hess;
+    }
+
+PYBIND11_MODULE(hazard, m) {
+    m.def("llk2", &llk2, "Second added of partial llk.");
+    m.def("grad2", &grad2, "Second added of gradient of partial llk.");
+    m.def("hessian", &hessian, "Hessian of partial llk.");
+}

--- a/src/mssm/src/python/exp_fam.py
+++ b/src/mssm/src/python/exp_fam.py
@@ -4264,7 +4264,6 @@ class PropHaz(GSMMFamily):
         """
         # Extract and define all variables defined by WPS (2016)
         ut = self.ut
-        r = self.r
         nt = len(ut)
         X = Xs[0]
         eta = X @ coef

--- a/src/mssm/src/python/exp_fam.py
+++ b/src/mssm/src/python/exp_fam.py
@@ -7,6 +7,7 @@ from itertools import repeat
 from collections.abc import Callable
 from .custom_types import DerivOrder
 from abc import ABC, abstractmethod
+import hazard
 
 HAS_MP = True
 try:
@@ -4015,6 +4016,12 @@ class PropHaz(GSMMFamily):
         self.__qs = None
         self.__avs = None
 
+        # Create index vectors ri for ut and r
+        idx = np.arange(len(self.r), dtype=np.int64)
+        self.__ris = []
+        for j in range(len(self.ut)):
+            self.__ris.append(idx[self.r == j])
+
     def llk(
         self,
         coef: np.ndarray,
@@ -4047,32 +4054,18 @@ class PropHaz(GSMMFamily):
         # Extract and define all variables defined by WPS (2016)
         delta = ys[0]
         ut = self.ut
-        r = self.r
         nt = len(ut)
-        X = Xs[0]
+        X = Xs[0].toarray()
         eta = X @ coef
 
-        with warnings.catch_warnings():  # Overflow
+        with warnings.catch_warnings():  # Overflow, etc.
             warnings.simplefilter("ignore")
             gamma = np.exp(eta)
 
-        # Now compute first sum
-        llk = np.sum(delta * eta)
-
-        # and second sum
-        gamma_p = 0
-        for j in range(nt):
-            ri = r == j
-            dj = np.sum(delta[ri])
-            with warnings.catch_warnings():  # Overflow
-                warnings.simplefilter("ignore")
-                gamma_p += np.sum(gamma[ri])
-
-            with warnings.catch_warnings():  # Divide by zero
-                warnings.simplefilter("ignore")
-                log_gamma_p = np.log(gamma_p)
-
-            llk -= dj * log_gamma_p
+            # Now compute first sum here and second sum in c
+            llk = np.sum(delta * eta) + hazard.llk2(
+                nt, gamma.flatten(), delta.flatten(), self.__ris
+            )
 
         return llk
 
@@ -4109,42 +4102,20 @@ class PropHaz(GSMMFamily):
         # Extract and define all variables defined by WPS (2016)
         delta = ys[0]
         ut = self.ut
-        r = self.r
         nt = len(ut)
-        X = Xs[0]
+        X = Xs[0].toarray()
         eta = X @ coef
 
-        with warnings.catch_warnings():  # Overflow
+        with warnings.catch_warnings():  # Overflow, etc.
             warnings.simplefilter("ignore")
             gamma = np.exp(eta)
-        gamma = gamma.reshape(-1, 1)
 
-        # Now compute first sum
-        g = delta.T @ X
+            # Now compute first sum here and second in c
+            g = (delta.T @ X).T + hazard.grad2(
+                nt, gamma.flatten(), delta.flatten(), self.__ris, X
+            ).reshape(-1, 1)
 
-        # and second sum
-        b_p = np.zeros_like(g)
-
-        gamma_p = 0
-        for j in range(nt):
-            ri = r == j
-            dj = np.sum(delta[ri])
-            gamma_i = (gamma[ri, 0]).reshape(-1, 1)
-            with warnings.catch_warnings():  # Overflow
-                warnings.simplefilter("ignore")
-                gamma_p += np.sum(gamma_i)
-
-            X_i = X[ri, :]
-            bi = gamma_i.T @ X_i
-            b_p += bi
-
-            with warnings.catch_warnings():  # Divide by zero
-                warnings.simplefilter("ignore")
-                bpg = b_p / gamma_p
-
-            g -= dj * bpg
-
-        return g.reshape(-1, 1)
+        return g
 
     def hessian(
         self,
@@ -4178,40 +4149,16 @@ class PropHaz(GSMMFamily):
         # Extract and define all variables defined by WPS (2016)
         delta = ys[0]
         ut = self.ut
-        r = self.r
         nt = len(ut)
-        X = Xs[0]
+        X = Xs[0].toarray()
         eta = X @ coef
 
         with warnings.catch_warnings():  # Overflow
             warnings.simplefilter("ignore")
             gamma = np.exp(eta)
-        gamma = gamma.reshape(-1, 1)
 
-        # Only sum over nt
-        b_p = np.zeros((1, X.shape[1]))
-
-        gamma_p = 0
-        A_p = scp.sparse.csc_array((X.shape[1], X.shape[1]))
-        H = scp.sparse.csc_array((X.shape[1], X.shape[1]))
-        for j in range(nt):
-            ri = r == j
-            dj = np.sum(delta[ri])
-            gamma_i = (gamma[ri, 0]).reshape(-1, 1)
-            gamma_p += np.sum(gamma_i)
-
-            X_i = X[ri, :]
-            bi = gamma_i.T @ X_i
-            b_p += bi
-
-            A_i = (gamma_i * X_i).T @ X_i
-            A_p += A_i
-
-            with warnings.catch_warnings():  # Divide by zero or overflow
-                warnings.simplefilter("ignore")
-                Hj = dj * b_p.T @ b_p / np.power(gamma_p, 2) - dj * A_p / gamma_p
-
-            H += Hj
+            # Compute hessian in cpp
+            H = hazard.hessian(nt, gamma.flatten(), delta.flatten(), self.__ris, X)
 
         return scp.sparse.csc_array(H)
 
@@ -4337,7 +4284,7 @@ class PropHaz(GSMMFamily):
         gamma_p = 0
         b_p = np.zeros((1, X.shape[1]))
         for j in range(nt):
-            ri = r == j
+            ri = self.__ris[j]
 
             # Get dj
             dj = np.sum(delta[ri])


### PR DESCRIPTION
**Overview**:
- Drastically speeds up estimation for proportional hazard models. Achieved by pre-computing indexing vectors once at family creation and handling the expensive looping in cpp
- Also sneaked in version bumps for actions still relying on node v20