### PR TITLE
Efficient computation of Cholesky of qEFS SR1 approximations

### DIFF
--- a/src/mssm/models.py
+++ b/src/mssm/models.py
@@ -706,7 +706,6 @@ class GSMM:
         build_mat: list[bool] | None = None,
         should_keep_drop: bool = True,
         gamma: float = 1,
-        qEFSH: str = "SR1",
         max_restarts: int = 0,
         prefit_grad: bool = True,
         repara: bool = True,
@@ -790,8 +789,8 @@ class GSMM:
             deficiencies and to drop coefficients that cannot be estimated given the current
             smoothing parameter values. This takes substantially longer. If this is set to
             ``'qEFS'``, then the coefficients are estimated via quasi netwon and the smoothing
-            penalties are estimated from the quasi newton approximation to the hessian. This only
-            requieres first derviative information. Defaults to "QR/Chol".
+            penalties are estimated from the quasi newton SR1 approximation to the hessian. This
+            only requieres first derviative information. Defaults to "QR/Chol".
         :type method: str,optional
         :param check_cond: Whether to obtain an estimate of the condition number for the linear
             system that is solved. When ``check_cond=0``, no check will be performed. When
@@ -841,10 +840,6 @@ class GSMM:
             models. Setting this to a value smaller than 1 (but must be > 0) promotes smoother
             models! Defaults to 1.
         :type gamma: float,optional
-        :param qEFSH: Should the hessian approximation use a symmetric rank 1 update
-            (``qEFSH='SR1'``) that is forced to result in positive semi-definiteness of the
-            approximation or the standard bfgs update (``qEFSH='BFGS'``). Defaults to 'SR1'.
-        :type qEFSH: str,optional
         :param max_restarts: How often to shrink the coefficient estimate back to a random vector
             when convergence is reached and when ``method='qEFS'``. The optimizer might get stuck
             in local minima so it can be helpful to set this to 1-3. What happens is that if we
@@ -1184,7 +1179,6 @@ class GSMM:
                 should_keep_drop,
                 form_VH,
                 gamma,
-                qEFSH,
                 max_restarts,
                 prefit_grad,
                 progress_bar,

--- a/src/mssm/src/cpp/dchol.cpp
+++ b/src/mssm/src/cpp/dchol.cpp
@@ -12,6 +12,23 @@
 
 namespace py = pybind11;
 
+void uChol(Eigen::Ref<Eigen::MatrixXd,0,Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> &L,
+           const Eigen::Ref<Eigen::MatrixXd,0,Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> &U,
+           double sigma)
+           {
+                /* Perform low-rank up/down-date of L using vectors making up column of U.
+                */
+                
+                // update/downdate
+                for (size_t i = 0; i < U.cols(); i++)
+                {
+                    Eigen::internal::llt_inplace<Eigen::Ref<Eigen::MatrixXd,0,
+                                                            Eigen::Stride<Eigen::Dynamic,
+                                                                          Eigen::Dynamic>>::Scalar,
+                                                 Eigen::Lower>::rankUpdate(L, U.col(i), sigma);
+                }
+           }
+
 Eigen::MatrixXd dChol(const Eigen::Ref<Eigen::MatrixXd,0,Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> &R,
                       const Eigen::Ref<Eigen::MatrixXd,0,Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> &A)
                 {
@@ -119,6 +136,7 @@ Eigen::MatrixXd computeV2(const Eigen::Ref<Eigen::MatrixXd,0,Eigen::Stride<Eigen
 
 
 PYBIND11_MODULE(dChol, m) {
+    m.def("uChol", &uChol, py::arg("L").noconvert(), py::arg("U").noconvert(), py::arg("sgima"), "Perform low-rank up/down-date of L using vectors making up column of U.");
     m.def("dChol", &dChol, py::arg("R").noconvert(), py::arg("A").noconvert(), "Let R be the transpose of Cholesky factor of some matrix H + a*A. Function returns derivative of this sum with respect to a.");
     m.def("invdChol", &invdChol, py::arg("R").noconvert(), py::arg("Rinv").noconvert(), py::arg("A").noconvert(), "Let R be the transpose of Cholesky factor of some matrix H + a*A and Rinv be the inverse of R. Function returns derivative of inverse of this sum with respect to a.");
     m.def("computeV2", &computeV2, "Computes second term of the smoothing penalty uncertainty correction proposed by Wood, S. N., Pya, N., Saefken, B., (2016).");

--- a/src/mssm/src/python/compact_rep.py
+++ b/src/mssm/src/python/compact_rep.py
@@ -1,4 +1,3 @@
-import copy
 import numpy as np
 import scipy as scp
 from .matrix_solvers import cpp_cholP, compute_Linv, apply_eigen_perm
@@ -52,240 +51,6 @@ def compute_omega(yks: np.ndarray, sks: np.ndarray, method: str = "NoWr") -> flo
         omega = 1
 
     return omega
-
-
-def computeH(
-    s: np.ndarray,
-    y: np.ndarray,
-    rho: np.ndarray,
-    H0: scp.sparse.csc_array,
-    explicit: bool = True,
-) -> (
-    np.ndarray
-    | tuple[
-        np.ndarray,
-        np.ndarray,
-        np.ndarray,
-        np.ndarray,
-    ]
-):
-    """Computes (explicitly or implicitly) the quasi-Newton approximation to the negative Hessian
-    of the (penalized) likelihood :math:`\\mathbf{H}` (:math:`\\mathcal{H}`) from the L-BFGS-B
-    optimizer info.
-
-    Relies on equations 2.16 in Byrd, Nocdeal & Schnabel (1992).
-
-    References:
-     - Byrd, R. H., Nocedal, J., & Schnabel, R. B. (1994). Representations of quasi-Newton \
-        matrices and their use in limited memory methods. Mathematical Programming, 63(1), \
-        129–156. https://doi.org/10.1007/BF01582063
-
-    :param s: np.ndarray of shape (m,p), where p is the number of coefficients, holding the first
-        set ``m`` of update vectors from Byrd, Nocdeal & Schnabel (1992).
-    :type s: np.ndarray
-    :param y: np.ndarray of shape (m,p), where p is the number of coefficients, holding the second
-        set ``m`` of update vectors from Byrd, Nocdeal & Schnabel (1992).
-    :type y: np.ndarray
-    :param rho: flattened numpy.array of shape (m,), holding element-wise ``1/y.T@s`` from Byrd,
-        Nocdeal & Schnabel (1992).
-    :type rho: np.ndarray
-    :param H0: Initial estimate for the hessian of the negative (penalized) likelihood. Here some
-        multiple of the identity (multiplied by ``omega``).
-    :type H0: scipy.sparse.csc_array
-    :param explicit: Whether or not to return the approximate matrix explicitly or implicitly in
-        form of four update matrices.
-    :type explicit: bool
-    :return: H, either as np.ndarray (``explicit=='True'``) or represented implicitly via four
-        update vectors (also np.ndarrays)
-    :rtype: np.ndarray | tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-    """
-    # Number of updates?
-    m = len(y)
-
-    # First form S,Y, and D
-    S = s.T
-    Y = y.T
-
-    STS = S.T @ H0 @ S
-    DK = np.identity(m)
-    DK[0, 0] *= np.dot(s[0], y[0])
-
-    # Now use eq. 2.5 to compute R - only have to do this once
-    R0 = np.dot(s[0], y[0]).reshape(1, 1)
-    R = R0
-    for k in range(1, m):
-
-        DK[k, k] *= np.dot(s[k], y[k])
-
-        R = np.concatenate(
-            (
-                np.concatenate((R0, S[:, :k].T @ Y[:, [k]]), axis=1),
-                np.concatenate(
-                    (np.zeros((1, R0.shape[1])), np.array([1 / rho[k]]).reshape(1, 1)),
-                    axis=1,
-                ),
-            ),
-            axis=0,
-        )
-
-        R0 = R
-
-    # Eq 2.22
-    L = S.T @ Y - R
-
-    # Now compute term 2 in 3.13 of Byrd, Nocdeal & Schnabel (1992)
-    t2 = np.zeros((2 * m, 2 * m))
-    t2[:m, :m] = STS
-    t2[:m, m:] = L
-    t2[m:, :m] = L.T
-    t2[m:, m:] = -1 * DK
-
-    # We actually need the inverse to compute H
-
-    # Eq 2.26 of Byrd, Nocdeal & Schnabel (1992)
-    Dinv = copy.deepcopy(DK)
-    Dpow = copy.deepcopy(DK)
-    Dnpow = copy.deepcopy(DK)
-    for k in range(m):
-        Dinv[k, k] = 1 / Dinv[k, k]
-        Dpow[k, k] = np.power(Dpow[k, k], 0.5)
-        Dnpow[k, k] = np.power(Dnpow[k, k], -0.5)
-
-    JJT = STS + L @ Dinv @ L.T
-    J = scp.linalg.cholesky(JJT, lower=True)
-
-    t2L = np.zeros((2 * m, 2 * m))
-    t2L[:m, :m] = Dpow
-    t2L[m:, :m] = (-1 * L) @ Dnpow
-    t2L[m:, m:] = J
-
-    t2U = np.zeros((2 * m, 2 * m))
-    t2U[:m, :m] = -1 * Dpow
-    t2U[:m:, m:] = Dnpow @ L.T
-    t2U[m:, m:] = J.T
-
-    t2_flip = t2L @ t2U
-
-    invt2L = scp.linalg.inv(t2L)
-    invT2U = scp.linalg.inv(t2U)
-    invt2 = invt2L.T @ invT2U.T
-
-    t2_sort = np.zeros((2 * m, 2 * m))
-    # top left <- bottom right
-    t2_sort[:m, :m] = t2_flip[m:, m:]
-    # top right <- bottom left
-    t2_sort[:m, m:] = t2_flip[m:, :m]
-    # bottom left <- top right
-    t2_sort[m:, :m] = t2_flip[:m, m:]
-    # bottom right <- top left
-    t2_sort[m:, m:] = t2_flip[:m, :m]
-
-    invt2_sort = np.zeros((2 * m, 2 * m))
-    # top left <- bottom right
-    invt2_sort[:m, :m] = invt2[m:, m:]
-    # top right <- bottom left
-    invt2_sort[:m, m:] = invt2[m:, :m]
-    # bottom left <- top right
-    invt2_sort[m:, :m] = invt2[:m, m:]
-    # bottom right <- top left
-    invt2_sort[m:, m:] = invt2[:m, :m]
-
-    # And terms 1 and 2
-    t1 = np.concatenate((H0 @ S, Y), axis=1)
-    t3 = np.concatenate((S.T @ H0, Y.T), axis=0)
-
-    # Return matrix in compact representation
-    if explicit is False:
-        return t1, (-1 * t2_sort), (-1 * invt2_sort), t3
-
-    H = H0 + t1 @ (-1 * invt2_sort) @ t3
-
-    return H
-
-
-def computeV(
-    s: np.ndarray,
-    y: np.ndarray,
-    rho: np.ndarray,
-    V0: scp.sparse.csc_array,
-    explicit: bool = True,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Computes (explicitly or implicitly) the quasi-Newton approximation to the inverse of the
-    negative Hessian of the (penalized) likelihood :math:`\\mathcal{I}` (:math:`\\mathbf{V}`)
-    from the L-BFGS-B optimizer info.
-
-    Relies on equations 2.16 and 3.13 in Byrd, Nocdeal & Schnabel (1992).
-
-    References:
-     - Byrd, R. H., Nocedal, J., & Schnabel, R. B. (1994). Representations of quasi-Newton \
-        matrices and their use in limited memory methods. Mathematical Programming, 63(1), \
-        129–156. https://doi.org/10.1007/BF01582063
-
-    :param s: np.ndarray of shape (m,p), where p is the number of coefficients, holding the
-        first set ``m`` of update vectors from Byrd, Nocdeal & Schnabel (1992).
-    :type s: np.ndarray
-    :param y: np.ndarray of shape (m,p), where p is the number of coefficients, holding the second
-        set ``m`` of update vectors from Byrd, Nocdeal & Schnabel (1992).
-    :type y: np.ndarray
-    :param rho: flattened numpy.array of shape (m,), holding element-wise ```1/y.T@s`` from Byrd,
-        Nocdeal & Schnabel (1992).
-    :type rho: np.ndarray
-    :param V0: Initial estimate for the inverse of the hessian of the negative (penalized)
-        likelihood. Here some multiple of the identity (multiplied by ``omega``).
-    :type V0: scipy.sparse.csc_array
-    :param explicit: Whether or not to return the approximate matrix explicitly or implicitly in
-        form of three update matrices.
-    :type explicit: bool
-    :return: V, either as np.ndarray (``explicit=='True'``) or represented implicitly via three
-        update vectors (also np.ndarrays)
-    :rtype: np.ndarray | tuple[np.ndarray, np.ndarray, np.ndarray]
-    """
-    m = len(y)
-    # First form S,Y, and D
-    S = s.T
-    Y = y.T
-
-    DYTY = Y.T @ V0 @ Y
-
-    DYTY[0, 0] += np.dot(s[0], y[0])
-
-    # Now use eq. 2.5 to compute R^{-1} - only have to do this once
-    Rinv0 = 1 / np.dot(s[0], y[0]).reshape(1, 1)
-    Rinv = Rinv0
-    for k in range(1, m):
-
-        DYTY[k, k] += np.dot(s[k], y[k])
-
-        Rinv = np.concatenate(
-            (
-                np.concatenate(
-                    (Rinv0, (-rho[k]) * Rinv0 @ S[:, :k].T @ Y[:, [k]]), axis=1
-                ),
-                np.concatenate(
-                    (np.zeros((1, Rinv0.shape[1])), np.array([rho[k]]).reshape(1, 1)),
-                    axis=1,
-                ),
-            ),
-            axis=0,
-        )
-
-        Rinv0 = Rinv
-
-    # Now compute term 2 in 3.13 used for all S_j
-    t2 = np.zeros((2 * m, 2 * m))
-    t2[:m, :m] = Rinv.T @ DYTY @ Rinv
-    t2[:m, m:] = -Rinv.T
-    t2[m:, :m] = -Rinv
-
-    # And terms 1 and 2
-    t1 = np.concatenate((S, V0 @ Y), axis=1)
-    t3 = np.concatenate((S.T, Y.T @ V0), axis=0)
-
-    if explicit:
-        V = V0 + t1 @ t2 @ t3
-        return V
-    else:
-        return t1, t2, t3
 
 
 def computeVSR1(
@@ -561,7 +326,6 @@ def computeSH(
     make_psd: bool = True,
     make_pd: bool = False,
     explicit: bool = True,
-    form: str = "SR1",
 ) -> (
     np.ndarray
     | tuple[
@@ -732,10 +496,6 @@ def computeSH(
     :param explicit: Whether or not to return the approximate matrix explicitly or implicitly in
         form of 8 update matrices, defaults to True
     :type explicit: bool
-    :param form: Should the quasi Newton Hessian approximation use a symmetric rank 1 update
-        (``qEFSH='SR1'``) that is forced to result in positive semi-definiteness of the
-        approximation or the standard bfgs update (``qEFSH='BFGS'``). Defaults to 'SR1'.
-    :type form: str
     :return: H, either as np.ndarray (``explicit=='True'``) or represented implicitly via an initial
         matrix and 8 update matrices as defined in the description (i.e.,
         ``nH1, nH2t1, nH2t2, nH2t3, nH3t1, nH3t3, nH4t1, nH4t2, nH4t3``).
@@ -795,19 +555,16 @@ def computeSH(
     H0 = scp.sparse.identity(nA, format="csc") * omega
 
     # Implicit representation of Schur complement SonHbbqa
-    if form == "SR1":
-        qat1, qat2, qat3 = computeHSR1(
-            sks,
-            yks,
-            rhos,
-            H0,
-            omega,
-            make_psd=make_psd,
-            explicit=False,
-            make_pd=make_pd,
-        )
-    else:
-        qat1, qat2, qat3 = computeH(sks, yks, rhos, H0, explicit=False)
+    qat1, qat2, qat3 = computeHSR1(
+        sks,
+        yks,
+        rhos,
+        H0,
+        omega,
+        make_psd=make_psd,
+        explicit=False,
+        make_pd=make_pd,
+    )
 
     if explicit:
         # At this point we can explicitly form the PSD approximation to nH (conH). First we define

--- a/src/mssm/src/python/gamm_solvers.py
+++ b/src/mssm/src/python/gamm_solvers.py
@@ -7613,7 +7613,7 @@ def getCholnH(
         # Combined indices in order so that quasi Newton block is bottom right
         tcols = [*fcols, *acols]
 
-        nF, nA, nT = len(fcols), len(acols), len(tcols)
+        nF, nT = len(fcols), len(tcols)
 
         # To compute ordered version of hessian we need first permutation matrix P1:
         # len(tcols) * len(tcols) permutation matrix transforming entire nH into order (onH) so that
@@ -7663,13 +7663,42 @@ def getCholnH(
         )
         E.append(R1)
 
-    # At this point only need to deal with t1 and t2 for both partial and full approximations
-
-    # Need Root of
+    # For both approximations, still need Root of
     # M = I*\omega + t1@t2@t1^T with M PSD but t2 indefinite
-    # Compute QR = t1 where QR is thin qr decomposition
-    # Now:
-    # M = I*\omega + QR@t2@R^TQ^T
+
+    # Root of I*\omega is simple:
+    if fcols is None:
+        R2 = scp.sparse.eye_array(t1.shape[0], format="csc") * np.sqrt(omega)
+
+    else:
+        R2 = np.zeros(t1.shape[0])
+        R2[acols] = np.sqrt(omega)
+        R2 = scp.sparse.diags_array(R2, format="csc")
+
+    E.append(R2)  # I*\omega
+
+    # Can now compute Cholesky/root of sum of all terms (i.e., E@E.T) but the quasi-newton
+    # modification.
+    E = scp.sparse.hstack(E, format="csr")
+
+    # Try out Cholesky on E@E.T
+    L, Pr, code = cpp_cholP((E @ E.T).tocsc())  # noqa: F405
+    L = L.toarray()
+    P = compute_eigen_perm(Pr).T  # noqa: F405
+
+    if code:
+        # Fall back to QR if E@E.T is only PSD
+
+        # QR decomposition: QR = E^T so E@E^T = R^T@Q^T@Q@R
+        # so R^T is desired Cholesky
+
+        R2, P, _, _ = cpp_qrr(E.T)  # noqa: F405
+        P = compute_eigen_perm(P)  # noqa: F405
+        L = R2.toarray().T
+
+    # At this point only need to deal with t1 and t2 for both partial and full approximations
+    # Speciifcally, need root of t1@t2@t1^T with M PSD but t2 indefinite.
+    # First Compute QR = t1 where QR is thin qr decomposition so M = I*\omega + QR@t2@R^TQ^T
     Q, R = scp.linalg.qr(t1, mode="economic")
 
     # Next get ev of R@t2@R^T
@@ -7681,36 +7710,17 @@ def getCholnH(
 
     # Next split eig2 into eig2+ = [positive | zero] and eig2- = [negative]
     # Then M = I*\omega + Q@U2@diag(eig2+)@U2^T@Q^T - Q@U2@diag(eig2-)@U2^T@Q^T
+    # Can apply the last two terms via Chol updating/downdating to Chol of E@E.T
 
-    # Roots of first two are simple:
-    if fcols is None:
-        R2 = scp.sparse.eye_array(t1.shape[0], format="csc") * np.sqrt(omega)
+    pos_idx = np.arange(len(eig2))[eig2 > 0]
 
-    else:
-        R2 = np.zeros(t1.shape[0])
-        R2[acols] = np.sqrt(omega)
-        R2 = scp.sparse.diags_array(R2, format="csc")
+    # First start with updating Cholesky from eig2+
+    if len(pos_idx) > 0:
+        U3 = P.T @ Q @ U2
+        U3 = U3[:, pos_idx] * np.sqrt(eig2[pos_idx])
 
-    E.append(R2)  # I*\omega
-
-    dsqrt = np.zeros_like(eig2)
-    dsqrt[eig2 > 0] = np.sqrt(eig2[eig2 > 0])
-    dsqrt2 = np.zeros_like(eig2)
-    dsqrt2[eig2 < 0] = np.sqrt(np.abs(eig2[eig2 < 0]))
-
-    R3 = Q @ U2 @ np.diag(dsqrt)
-
-    E.append(scp.sparse.csc_array(R3))  # Q@U2@diag(eig2+)@U2^T@Q^T
-
-    # Form E
-    E = scp.sparse.hstack(E, format="csr")
-
-    # QR decomposition: QR = E^T so E@E^T = npH = R^T@Q^T@Q@R
-    # so R^T is desired Cholesky - **if eig2- is empty**
-
-    R2, P, _, _ = cpp_qrr(E.T)
-    P = compute_eigen_perm(P)
-    L = R2.toarray().T
+        # Update
+        dChol.uChol(L, U3, 1)
 
     # if eig2- is not empty, we still need a couple of downdates
     neg_idx = np.arange(len(eig2))[eig2 < 0]
@@ -9698,17 +9708,32 @@ def solve_generalSmooth_sparse(
         # Optionally form last V + Chol explicitly during last iteration
         # when working with qEFS update
         if form_VH:
-            _, _, S_root, _ = compute_S_emb_pinv_det(
-                len(coef), smooth_pen, "svd", root=True
-            )
 
             H = -1 * getExplicitnH(LV, len(coef), True, True)
 
             # Get Cholesky factor of inverse of penalized hessian (needed for CIs)
-            pL, P = getCholnH(LV, len(coef), S_root, make_pd=True)
-            pLV = compute_Linv(pL, n_c)  # noqa: F405
-            L = P @ pL
-            LV = pLV @ P.T
+            if len(LV_linop.yk) > (0.3 * len(coef)):
+                # Simply compute full Cholesky
+                pH = scp.sparse.csc_array((-1 * H) + S_emb)
+                Lp, Pr, _ = cpp_cholP(pH)  # noqa: F405
+                P = compute_eigen_perm(Pr).T  # noqa: F405
+            else:
+                # Update Cholesky factor with quasi-Newton block
+
+                # First need root of S_emb:
+                if len(smooth_pen) > 0:
+                    _, _, S_root, _ = compute_S_emb_pinv_det(
+                        len(coef), smooth_pen, "svd", root=True
+                    )
+                else:
+                    S_root = S_norm.copy()
+
+                # Then accumulate Cholesky
+                Lp, P = getCholnH(LV, len(coef), S_root, make_pd=True)
+
+            LVp = compute_Linv(Lp, n_c)  # noqa: F405
+            L = P @ Lp
+            LV = LVp @ P.T
 
         else:
             LV = None

--- a/src/mssm/src/python/gamm_solvers.py
+++ b/src/mssm/src/python/gamm_solvers.py
@@ -22,7 +22,6 @@ from .formula import (
 )
 from .file_loading import setup_cache, clear_cache
 from .compact_rep import (
-    computeH,
     computeHSR1,
     compute_omega,
     computeSH,
@@ -757,7 +756,6 @@ def getImplicitV(
 
     # Extract info to determine which strategy was used to approximate H
     sample_hessian = linopH.sample_hessian
-    form = linopH.form
     fcols = linopH.fcols
 
     # Get all the update vectors
@@ -800,50 +798,24 @@ def getImplicitV(
             # Below we get int2, with the shifted Eigenvalues so that
             # H = H0 + nt1 @ int2 @ nt3 - where H0 = I*omega + S_emb and
             # I*omega + nt1 @ int2 @ nt3 is PSD.
-            # Now, using the Woodbury identity:
-            # V = (H)^-1 = V0 - V0@nt1@ (int2^-1 + nt3@V0@nt1)^-1 @ nt3@V0
-            #
-            # since nt3=nt1.T, and int2^-1 = nt2 we have:
-            #
-            # V = V0 - V0@nt1@ (nt2 + nt1.T@V0@nt1)^-1 @ nt1.t@V0
-            #
+            nt1, int2, nt3 = computeHSR1(
+                s, y, rho, H0, omega, make_psd=True, explicit=False
+            )
 
-            # Compute inverse:
-            if form != "SR1":
-                nt1, nt2, int2, nt3 = computeH(s, y, rho, H0, explicit=False)
+            # When using SR1 int2 is potentially singular, so we need a modified Woodbury
+            # that accounts for that. This is given by eq. 23 in Henderson & Searle (1981):
+            invt2 = np.identity(int2.shape[1]) + int2 @ nt3 @ V0 @ nt1
 
-                invt2 = nt2 + nt3 @ V0 @ nt1
+            U, sv_invt2, VT = scp.linalg.svd(invt2, lapack_driver="gesvd")
 
-                U, sv_invt2, VT = scp.linalg.svd(invt2, lapack_driver="gesvd")
+            # Nowe we can compute all parts for the modified Woodbury identy to
+            # obtain V
+            t2 = VT.T @ np.diag(1 / sv_invt2) @ U.T
+            t1 = V0 @ nt1
+            t3 = int2 @ nt3 @ V0
 
-                # Nowe we can compute all parts for the Woodbury identy to obtain V
-                t2 = VT.T @ np.diag(1 / sv_invt2) @ U.T
+            # We now have: V = V0 - V0@nt1@t2@nt3@V0, but don't have to form that explicitly!
 
-                t1 = V0 @ nt1
-                t3 = nt3 @ V0
-            else:
-                nt1, int2, nt3 = computeHSR1(
-                    s, y, rho, H0, omega, make_psd=True, explicit=False
-                )
-
-                # When using SR1 int2 is potentially singular, so we need a modified Woodbury
-                # that accounts for that. This is given by eq. 23 in Henderson & Searle (1981):
-                invt2 = np.identity(int2.shape[1]) + int2 @ nt3 @ V0 @ nt1
-
-                U, sv_invt2, VT = scp.linalg.svd(invt2, lapack_driver="gesvd")
-
-                # Nowe we can again compute all parts for the modified Woodbury identy to
-                # obtain V
-                t2 = VT.T @ np.diag(1 / sv_invt2) @ U.T
-
-                t1 = V0 @ nt1
-                t3 = int2 @ nt3 @ V0
-
-            # We now have: V = V0 - V0@nt1@t2@nt3@V0, but don't have to form that explcitly!
-            # V3 = V0 - V0@nt1@t2@nt3@V0
-            # LVPT, P, code = cpp_cholP(scp.sparse.csc_array(V3))
-            # LVT = apply_eigen_perm(P,LVPT)
-            # LV = LVT.T
         t4 = None
         t5 = None
         t6 = None
@@ -882,7 +854,6 @@ def getImplicitV(
             dampen_HBb <= 0,
             dampen_HBB,
             explicit=False,
-            form=form,
         )
 
         (
@@ -6854,7 +6825,6 @@ def update_ys_qefs(
     step: np.ndarray | None,
     alpha: float | None,
     skip: bool,
-    form: str,
     maxcor: int,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, float, bool]:
     """Determines new update vectors ``yk`` and ``sk`` as well as new values for ``rho`` and
@@ -6890,14 +6860,12 @@ def update_ys_qefs(
     :param skip: Whether to skip accumulating the update vectors based on ``grad_up``, ``step``,
         and ``next_grad_up`` (For example if step search failed).
     :type skip: bool
-    :param form: Which update to use: "SR1" or "LBFGS"
-    :type form: str
     :param maxcor: Maximum number of update vectors to retain as part of the limited memory
         approximations to the hessian/inverse.
     :type maxcor: int
     :return: Updated values for ``yks``, ``sks``, ``rhos``, as well as ``omega`` (latest
         estimate of eigenvalue of hessian) and ``skip`` reflecting the updated decision on whether
-        to collect the update vectors for the "SR1" update (is always the same if ``form='LBFGS'``).
+        to collect the update vectors for the "SR1" update.
     :rtype: tuple[np.ndarray, np.ndarray, np.ndarray, float, bool]
     """
 
@@ -6915,36 +6883,11 @@ def update_ys_qefs(
                 skip = True
 
     if skip is False:
-
-        if form == "SR1":
-            # Check if SR1 update is defined (see Nocedal & Wright, 2004)
-            skip = test_SR1(sk, yk, rhok, sks, yks, rhos)
-        else:
-            # Check curvature condition for BFGS
-            skip = yk.T @ sk > 0
+        # Check if SR1 update is defined (see Nocedal & Wright, 2004)
+        skip = test_SR1(sk, yk, rhok, sks, yks, rhos)
 
     if skip is False:
-        # Wolfe/Armijo met, can collect update vectors
-
-        if form != "SR1" and len(sks) > 0:
-            # But first check for dampen for BFGS update - see Nocedal & Wright (2004):
-
-            # Need previous omega
-            if sks.shape[0] > 0:
-                omega = compute_omega(yks, sks)
-            else:
-                omega = 1
-
-            # Initialize hessian
-            H0 = scp.sparse.identity(len(sk), format="csc") * omega
-
-            Ht1, _, Ht2, Ht3 = computeH(sks, yks, rhos, H0, explicit=False)
-            Bs = H0 @ sk + Ht1 @ Ht2 @ Ht3 @ sk
-            sBs = sk.T @ Bs
-
-            if sk.T @ yk < 0.2 * sBs:
-                theta = (0.8 * sBs) / (sBs - sk.T @ yk)
-                yk = theta * yk + (1 - theta) * Bs
+        # Update defined, can collect update vectors
 
         # Collect
         if len(sks) == 0:
@@ -6979,7 +6922,6 @@ def sample_ys_qefs(
     coef: np.ndarray,
     coef_split_idx: list[int],
     S_emb: scp.sparse.csc_array,
-    form: str,
     maxcor: int,
     method: int,
     seed: int,
@@ -7022,8 +6964,6 @@ def sample_ys_qefs(
     :type coef_split_idx: list[int]
     :param S_emb: Total penalty matrix
     :type S_emb: scp.sparse.csc_array
-    :param form: Which update to use: "SR1" or "LBFGS"
-    :type form: str
     :param maxcor: Maximum number of update vectors to retain as part of the limited memory
         approximations to the hessian/inverse.
     :type maxcor: int
@@ -7179,7 +7119,6 @@ def sample_ys_qefs(
                 step0,
                 r,
                 False,
-                form,
                 maxcor,
             )
 
@@ -7226,7 +7165,6 @@ def sample_ys_qefs(
                 None,
                 None,
                 False,
-                form,
                 maxcor,
             )
 
@@ -7338,7 +7276,6 @@ def makepdd_fd2llk(
 
 def init_qEFS_storage(
     coef: np.ndarray,
-    qEFSH: str,
     bfgs_options: dict,
     sample_hessian: bool,
     sample_hessian_method: int,
@@ -7346,15 +7283,12 @@ def init_qEFS_storage(
     fcols: np.ndarray,
     sqEFS_options: dict,
 ) -> scp.optimize.LbfgsInvHessProduct:
-    """Initializes storage to hold l-qEFS approximations to the negative Hessian.
+    """Initializes storage to hold l-qEFS SR1 approximations to the negative Hessian.
 
     Returns a ``scp.optimize.LbfgsInvHessProduct`` object with extra attributes.
 
     :param coef: Coefficient array
     :type coef: np.ndarray
-    :param qEFSH: Should the hessian approximation use a symmetric rank 1 update (``qEFSH='SR1'``)
-        that is forced to result in positive semi-definiteness of the approximation or the standard
-        bfgs update (``qEFSH='BFGS'``)
     :param bfgs_options: An optional dictionary holding arguments that should be passed on to the
         call of :func:`scipy.optimize.minimize` if ``method=='qEFS'``.
     :type bfgs_options: dict
@@ -7397,7 +7331,6 @@ def init_qEFS_storage(
     opt_storage.init = False
 
     opt_storage.method = "qEFS"
-    opt_storage.form = qEFSH
     opt_storage.bfgs_options = bfgs_options
     opt_storage.sample_hessian = sample_hessian
     opt_storage.sample_hessian_method = sample_hessian_method
@@ -7478,23 +7411,16 @@ def getExplicitnH(
             omega = 1
 
         # Get an approximation of the Hessian of the likelihood
-        if linopH.form == "SR1":
-            nH = computeHSR1(
-                linopH.sk,
-                linopH.yk,
-                linopH.rho,
-                scp.sparse.identity(n_coef, format="csc") * omega,
-                omega=omega,
-                make_psd=make_psd,
-                make_pd=make_pd,
-            )
-        else:
-            nH = computeH(
-                linopH.sk,
-                linopH.yk,
-                linopH.rho,
-                scp.sparse.identity(n_coef, format="csc") * omega,
-            )
+        nH = computeHSR1(
+            linopH.sk,
+            linopH.yk,
+            linopH.rho,
+            scp.sparse.identity(n_coef, format="csc") * omega,
+            omega=omega,
+            make_psd=make_psd,
+            make_pd=make_pd,
+        )
+
     else:
         dampen_HBb = (
             linopH.sqEFS_options["dampen_HBb"]
@@ -7520,7 +7446,6 @@ def getExplicitnH(
             dampen_HBB,
             make_psd=make_psd,
             make_pd=make_pd,
-            form=linopH.form,
         )
 
     return scp.sparse.csc_array(nH)
@@ -7595,7 +7520,6 @@ def getCholnH(
             dampen_HBB,
             make_psd=True,
             make_pd=make_pd,
-            form=linopH.form,
             explicit=False,
         )
         t1 = t1.toarray()
@@ -7881,7 +7805,6 @@ def sampleHcoef(
             coef,
             coef_split_idx,
             S_emb,
-            linopH.form,
             linopH.bfgs_options["maxcor"],
             sample_hessian_method,
             seed,
@@ -8058,8 +7981,6 @@ def update_coef_gen_smooth(
                 [grad[i] - (S_emb[[i], :] @ coef)[0] for i in range(len(grad))]
             )
             return -1 * pgrad.flatten()
-
-        form = opt_raw.form
 
         # Sampling options
         sample_hessian = opt_raw.sample_hessian
@@ -8293,7 +8214,6 @@ def update_coef_gen_smooth(
                     coef,
                     coef_split_idx,
                     S_emb,
-                    form,
                     maxcor,
                     sample_hessian_method,
                     outer + attempts,
@@ -8462,7 +8382,6 @@ def update_coef_gen_smooth(
         LV = scp.optimize.LbfgsInvHessProduct(sks, yks)
         LV.nit = opt["nit"]
         LV.method = "qEFS"
-        LV.form = form
         LV.sample_hessian = sample_hessian
         LV.sample_hessian_method = sample_hessian_method
         LV.sample_hessian_options = sample_hessian_options
@@ -9115,7 +9034,6 @@ def solve_generalSmooth_sparse(
     should_keep_drop: bool = True,
     form_VH: bool = True,
     gamma: float = 1,
-    qEFSH: str = "SR1",
     max_restarts: int = 0,
     prefit_grad: bool = False,
     progress_bar: bool = True,
@@ -9239,10 +9157,6 @@ def solve_generalSmooth_sparse(
         Setting this to a value smaller than 1 (but must be > 0) promotes smoother models,
         defaults to 1
     :type gamma: float, optional
-    :param qEFSH: Should the hessian approximation use a symmetric rank 1 update (``qEFSH='SR1'``)
-        that is forced to result in positive semi-definiteness of the approximation or the standard
-        bfgs update (``qEFSH='BFGS'``), defaults to 'SR1'
-    :type qEFSH: str, optional
     :param max_restarts: How often to shrink the coefficient estimate back to a random vector when
         convergence is reached and when ``method='qEFS'``. The optimizer might get stuck in local
         minima so it can be helpful to set this to 1-3. What happens is that if we converge, we
@@ -9418,7 +9332,6 @@ def solve_generalSmooth_sparse(
         if method != "qEFS"
         else init_qEFS_storage(
             coef,
-            qEFSH,
             bfgs_options,
             sample_hessian,
             sample_hessian_method,

--- a/src/mssm/src/python/gamm_solvers.py
+++ b/src/mssm/src/python/gamm_solvers.py
@@ -7456,7 +7456,26 @@ def getCholnH(
     n_coef: int,
     S_root: scp.sparse.csc_array,
     make_pd: bool = True,
-):
+) -> tuple[scp.sparse.csc_array, scp.sparse.csc_array]:
+    """Compute Cholesky of the pivoted quasi-Newton approximation to the negative Hessian of the
+    penalized log-likelihood.
+
+    :param linopH: Storage holding current quasi-newton approximation of the negative Hessian
+        of the llk. Storage needs to be of the form returned by :func:`init_qEFS_storage`.
+    :type linopH: scp.sparse.linalg.LinearOperator
+    :param n_coef: Number of coefficients
+    :type n_coef: int
+    :param S_root: Root of the total (weighted) penalty matrix
+    :type S_root: scp.sparse.csc_array
+    :param make_pd: Whether to enforce the Hessian approximation to be PD (otherwise only PSD is
+        enforced), defaults to True
+    :type make_pd: bool, optional
+    :return: Cholesky ``Lp`` of the pivoted quasi-Newton approximation to the negative Hessian of
+        the penalized log-likelihood and the pivot matrix so that ``P@Lp`` gives the unpivoted
+        matrix ``L@L.T=nH`` with ``nH`` for the quasi-Newton approximation to the negative Hessian
+        of the penalized log-likelihood.
+    :rtype: tuple[scp.sparse.csc_array, scp.sparse.csc_array]
+    """
 
     sample_hessian = linopH.sample_hessian
     fcols = linopH.fcols

--- a/src/mssm/src/python/gamm_solvers.py
+++ b/src/mssm/src/python/gamm_solvers.py
@@ -28,6 +28,7 @@ from .compact_rep import (
     computeSH,
     computeSVPS,
 )
+import dChol
 from .repara import reparam_model
 from functools import reduce
 from .custom_types import Fit_info, LambdaTerm, DerivOrder
@@ -7525,6 +7526,205 @@ def getExplicitnH(
     return scp.sparse.csc_array(nH)
 
 
+def getCholnH(
+    linopH: scp.sparse.linalg.LinearOperator,
+    n_coef: int,
+    S_root: scp.sparse.csc_array,
+    make_pd: bool = True,
+):
+
+    sample_hessian = linopH.sample_hessian
+    fcols = linopH.fcols
+    acols = linopH.acols
+    IonHBB = linopH.IonHBB
+    nHfd = linopH.nHfd
+
+    # Update matrices associated with quasi-Newton block
+    t1 = None
+    t2 = None
+
+    E = [S_root]
+
+    if fcols is None:
+        # Full approximation
+        if len(linopH.yk) > 0:
+            omega = compute_omega(
+                linopH.yk, linopH.sk, method="mean" if sample_hessian else "NoWr"
+            )
+        else:
+            omega = 1
+
+        t1, t2, _ = computeHSR1(
+            linopH.sk,
+            linopH.yk,
+            linopH.rho,
+            scp.sparse.identity(n_coef, format="csc") * omega,
+            omega=omega,
+            make_psd=True,
+            make_pd=make_pd,
+            explicit=False,
+        )
+
+    else:
+        # Partial approximation
+        dampen_HBb = (
+            linopH.sqEFS_options["dampen_HBb"]
+            if "dampen_HBb" in linopH.sqEFS_options
+            else 1
+        )
+
+        dampen_HBB = (
+            linopH.sqEFS_options["dampen_HBB"]
+            if "dampen_HBB" in linopH.sqEFS_options
+            else 1
+        )
+
+        PD_HBB = (
+            linopH.sqEFS_options["PD_HBB"] if "PD_HBB" in linopH.sqEFS_options else True
+        )
+
+        _, _, _, _, _, _, t1, t2, _ = computeSH(
+            linopH.yk,
+            linopH.sk,
+            nHfd,
+            IonHBB,
+            fcols,
+            acols,
+            sample_hessian,
+            dampen_HBb <= 0,
+            dampen_HBB,
+            make_psd=True,
+            make_pd=make_pd,
+            form=linopH.form,
+            explicit=False,
+        )
+        t1 = t1.toarray()
+
+        # Re-compute omega as done by computeSH
+        if len(linopH.yk) > 0:
+            omega = dampen_HBB * compute_omega(
+                linopH.yk[:, acols],
+                linopH.sk[:, acols],
+                method="mean" if sample_hessian else "NoWr",
+            )
+        else:
+            omega = 1
+
+        # Combined indices in order so that quasi Newton block is bottom right
+        tcols = [*fcols, *acols]
+
+        nF, nA, nT = len(fcols), len(acols), len(tcols)
+
+        # To compute ordered version of hessian we need first permutation matrix P1:
+        # len(tcols) * len(tcols) permutation matrix transforming entire nH into order (onH) so that
+        # fd approximated block is top left and quasi Newton block is bottom right via
+        # onH = P1.T @ nH @ P1
+        P1 = scp.sparse.csc_array(
+            (
+                np.tile(1, nT),
+                (tcols, np.arange(nT)),
+            ),
+            shape=(nT, nT),
+        )
+
+        # Now can compute ordered version of finite difference approximated part of nH and extract
+        # the relevant blocks
+        onHfd = P1.T @ nHfd @ P1
+
+        # Can now extract the block on the diagonal and the off-diagonals holding the mixed derivs
+        # onHBB should be PD
+        # onHBb might have been dampened.
+        onHBB = onHfd[np.ix_(np.arange(nF), np.arange(nF))]
+        onHBb = onHfd[np.ix_(np.arange(nF), np.arange(nF, nT))]
+
+        # Now Eigen-decomposition of onHBB
+        eig, U = scp.linalg.eigh(onHBB.toarray())
+        eig[eig < 0] = 0  # Must be PSD for Chol to make sense
+
+        if PD_HBB:
+            eps = np.power(np.finfo(float).eps, 0.5)
+            thresh = eps * np.max(np.abs(eig))
+            eig[eig < thresh] = thresh
+
+        ieig = np.zeros_like(eig)
+        ieig[eig > 0] = 1 / eig[eig > 0]
+
+        dsqrt = np.zeros_like(eig)
+        idsqrt = np.zeros_like(eig)
+        dsqrt[eig > 0] = np.sqrt(eig[eig > 0])
+        idsqrt[ieig > 0] = np.sqrt(ieig[ieig > 0])
+
+        # Collect first "root"
+        R1 = P1 @ scp.sparse.vstack(
+            [
+                scp.sparse.csc_array(U @ np.diag(dsqrt)),
+                scp.sparse.csc_array(onHBb.T @ U @ np.diag(idsqrt)),
+            ],
+        )
+        E.append(R1)
+
+    # At this point only need to deal with t1 and t2 for both partial and full approximations
+
+    # Need Root of
+    # M = I*\omega + t1@t2@t1^T with M PSD but t2 indefinite
+    # Compute QR = t1 where QR is thin qr decomposition
+    # Now:
+    # M = I*\omega + QR@t2@R^TQ^T
+    Q, R = scp.linalg.qr(t1, mode="economic")
+
+    # Next get ev of R@t2@R^T
+    Rt2R = R @ t2 @ R.T
+    eig2, U2 = scp.linalg.eigh(Rt2R, driver="ev")
+
+    # Now:
+    # M = I*\omega + Q@U2@diag(eig2)@U2^T@Q^T
+
+    # Next split eig2 into eig2+ = [positive | zero] and eig2- = [negative]
+    # Then M = I*\omega + Q@U2@diag(eig2+)@U2^T@Q^T - Q@U2@diag(eig2-)@U2^T@Q^T
+
+    # Roots of first two are simple:
+    if fcols is None:
+        R2 = scp.sparse.eye_array(t1.shape[0], format="csc") * np.sqrt(omega)
+
+    else:
+        R2 = np.zeros(t1.shape[0])
+        R2[acols] = np.sqrt(omega)
+        R2 = scp.sparse.diags_array(R2, format="csc")
+
+    E.append(R2)  # I*\omega
+
+    dsqrt = np.zeros_like(eig2)
+    dsqrt[eig2 > 0] = np.sqrt(eig2[eig2 > 0])
+    dsqrt2 = np.zeros_like(eig2)
+    dsqrt2[eig2 < 0] = np.sqrt(np.abs(eig2[eig2 < 0]))
+
+    R3 = Q @ U2 @ np.diag(dsqrt)
+
+    E.append(scp.sparse.csc_array(R3))  # Q@U2@diag(eig2+)@U2^T@Q^T
+
+    # Form E
+    E = scp.sparse.hstack(E, format="csr")
+
+    # QR decomposition: QR = E^T so E@E^T = npH = R^T@Q^T@Q@R
+    # so R^T is desired Cholesky - **if eig2- is empty**
+
+    R2, P, _, _ = cpp_qrr(E.T)
+    P = compute_eigen_perm(P)
+    L = R2.toarray().T
+
+    # if eig2- is not empty, we still need a couple of downdates
+    neg_idx = np.arange(len(eig2))[eig2 < 0]
+
+    if len(neg_idx) > 0:
+        U3 = P.T @ Q @ U2
+        U3 = U3[:, neg_idx] * np.sqrt(np.abs(eig2[neg_idx]))
+
+        # Downdate
+        dChol.uChol(L, U3, -1)
+
+    return scp.sparse.csc_array(L), P
+
+
 def sampleHcoef(
     linopH: scp.sparse.linalg.LinearOperator,
     family: GSMMFamily,
@@ -9498,16 +9698,17 @@ def solve_generalSmooth_sparse(
         # Optionally form last V + Chol explicitly during last iteration
         # when working with qEFS update
         if form_VH:
+            _, _, S_root, _ = compute_S_emb_pinv_det(
+                len(coef), smooth_pen, "svd", root=True
+            )
 
             H = -1 * getExplicitnH(LV, len(coef), True, True)
 
             # Get Cholesky factor of inverse of penalized hessian (needed for CIs)
-            pH = scp.sparse.csc_array((-1 * H) + S_emb)
-            Lp, Pr, _ = cpp_cholP(pH)  # noqa: F405
-            P = compute_eigen_perm(Pr)  # noqa: F405
-            LVp0 = compute_Linv(Lp, n_c)  # noqa: F405
-            LV = apply_eigen_perm(Pr, LVp0)  # noqa: F405
-            L = P.T @ Lp
+            pL, P = getCholnH(LV, len(coef), S_root, make_pd=True)
+            pLV = compute_Linv(pL, n_c)  # noqa: F405
+            L = P @ pL
+            LV = pLV @ P.T
 
         else:
             LV = None

--- a/src/mssm/src/python/utils.py
+++ b/src/mssm/src/python/utils.py
@@ -137,7 +137,7 @@ class GAMLSSGSMMFamily(GSMMFamily):
 
         model.fit(init_coef=None,method='qEFS',extend_lambda=False,
                 control_lambda=0,max_outer=200,max_inner=500,min_inner=500,
-                seed=0,qEFSH='SR1',max_restarts=5,overwrite_coef=False,
+                seed=0,max_restarts=5,overwrite_coef=False,
                 qEFS_init_converge=False,prefit_grad=True,
                 progress_bar=True,**bfgs_opt)
 
@@ -166,7 +166,7 @@ class GAMLSSGSMMFamily(GSMMFamily):
 
         model.fit(init_coef=None,method='qEFS',extend_lambda=False,
                 control_lambda=0,max_outer=200,max_inner=500,min_inner=500,
-                seed=0,qEFSH='SR1',max_restarts=0,overwrite_coef=False,
+                seed=0,max_restarts=0,overwrite_coef=False,
                 qEFS_init_converge=False,prefit_grad=True,
                 progress_bar=True,**bfgs_opt)
 
@@ -2011,7 +2011,6 @@ def compute_REML_candidate_GSMM(
                 )
                 __old_opt.init = False
                 __old_opt.method = "qEFS"
-                __old_opt.form = "SR1"
                 __old_opt.bfgs_options = bfgs_options
                 __old_opt.sample_hessian = True
                 __old_opt.sample_hessian_method = 0

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -90,7 +90,6 @@ default_gsmm_test_kwargs = {
     "should_keep_drop": True,
     "gamma": 1,
     "bfgs_options": None,
-    "qEFSH": "SR1",
     "max_restarts": 0,
     "prefit_grad": False,
     "repara": False,

--- a/tests/test_gsmm.py
+++ b/tests/test_gsmm.py
@@ -29,6 +29,111 @@ mssm.src.python.utils.GAMLSSGSMMFamily.init_coef = init_coef_gsmmgammlss
 ################################################################## Tests ##################################################################
 
 
+class Test_Chol_updating:
+    sim_dat = sim12(5000, c=0, seed=0, family=GAMMALS([LOG(), LOG()]), n_ranef=20)
+
+    # We again need to model the mean: \mu_i = \alpha + f(x0) + f(x1) + f_{x4}(x0)
+    sim_formula_m = Formula(
+        lhs("y"), [i(), f(["x0"], id=1), f(["x1"]), fs(["x0"], rf="x4")], data=sim_dat
+    )
+
+    # and the standard deviation as well: log(\sigma_i) = \alpha + f(x2) + f(x3)
+    sim_formula_sd = Formula(lhs("y"), [i(), f(["x2"], id=1), f(["x3"])], data=sim_dat)
+
+    family = GAMMALS([LOG(), LOGb(-0.0001)])
+
+    test_kwargs = copy.deepcopy(default_gsmm_test_kwargs)
+    test_kwargs["control_lambda"] = 1
+    test_kwargs["extend_lambda"] = False
+    test_kwargs["max_outer"] = 20
+    test_kwargs["max_inner"] = 500
+    test_kwargs["method"] = "qEFS"
+    test_kwargs["repara"] = True
+    test_kwargs["prefit_grad"] = True
+    test_kwargs["sample_hessian_options"] = {"T": 0.1, "delta": 1}
+    test_kwargs["max_restarts"] = -1
+    test_kwargs["sample_hessian"] = True
+    test_kwargs["structured_qefs"] = True
+    test_kwargs["n_cores"] = 4
+    test_kwargs["sqEFS_options"] = {
+        "dampen_HBB": 0.1,
+        "dampen_HBb": 1,
+        "pre_cond": False,
+        "PD_HBB": False,
+    }
+    test_kwargs["qEFS_memory_usage"] = (
+        0.25  # Low enough memory to trigger Chol updating
+    )
+    test_kwargs["bfgs_options"] = None
+
+    def callback(outer, pen_llk, coef, lam):
+        print(outer, pen_llk, lam)
+
+    # Now define the model and fit!
+    gsmm_fam = GAMLSSGSMMFamily(2, family)
+    model = GSMM([sim_formula_m, sim_formula_sd], gsmm_fam)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        model.fit(**test_kwargs, callback=callback)
+
+    def test_GAMedf(self):
+        np.testing.assert_allclose(
+            self.model.edf,
+            107.65988689459013,
+            atol=min(max_atol, 0),
+            rtol=min(max_rtol, 0.1),
+        )
+
+    def test_edf1(self):
+        compute_bias_corrected_edf(self.model, overwrite=False)
+        edf1 = np.array([edf1 for edf1 in self.model.term_edf1])
+        np.testing.assert_allclose(
+            edf1,
+            np.array(
+                [
+                    6.822003954437688,
+                    4.85270654666088,
+                    119.85131677237061,
+                    6.926201285757667,
+                    2.211716646272749,
+                ]
+            ),
+            atol=min(max_atol, 0),
+            rtol=min(max_rtol, 1.5),
+        )
+
+    def test_ps(self):
+        ps = []
+        for par in range(len(self.model.formulas)):
+            pps, _ = approx_smooth_p_values(self.model, par=par)
+            ps.extend(pps)
+        np.testing.assert_allclose(
+            ps,
+            np.array([0.0, 0.0, 0.0, 0.10946942004018534]),
+            atol=min(max_atol, 0),
+            rtol=min(max_rtol, 0.5),
+        )
+
+    def test_TRs(self):
+        Trs = []
+        for par in range(len(self.model.formulas)):
+            _, pTrs = approx_smooth_p_values(self.model, par=par)
+            Trs.extend(pTrs)
+        np.testing.assert_allclose(
+            Trs,
+            np.array(
+                [
+                    56.579810558691,
+                    2709.9201524805353,
+                    237.11272829051055,
+                    4.758159728976485,
+                ]
+            ),
+            atol=min(max_atol, 0),
+            rtol=min(max_rtol, 1.5),
+        )
+
+
 class Test_qefs_final_budget:
     sim_dat = sim4(500, 2, family=Gamma(), seed=0)
 

--- a/tests/test_gsmm.py
+++ b/tests/test_gsmm.py
@@ -284,185 +284,6 @@ class Test_repara_skip:
         )
 
 
-class Test_GAUMLSSGEN_hard:
-
-    # Simulate 500 data points
-    sim_dat = sim3(
-        500, 2, c=1, seed=0, family=Gaussian(), binom_offset=0, correlate=False
-    )
-
-    # We need to model the mean: \mu_i
-    formula_m = Formula(
-        lhs("y"), [i(), f(["x0"]), f(["x1"]), f(["x2"]), f(["x3"])], data=sim_dat
-    )
-
-    # And for sd - here constant
-    formula_sd = Formula(lhs("y"), [i()], data=sim_dat)
-
-    # Collect both formulas
-    formulas = [formula_m, formula_sd]
-    links = [Identity(), LOG()]
-
-    # Now define the general family + model and fit!
-    gsmm_fam = GAMLSSGSMMFamily(2, GAUMLSS(links))
-    model = GSMM(formulas=formulas, family=gsmm_fam)
-
-    # fit with BFGS
-    bfgs_opt = {"gtol": 1e-7, "ftol": 1e-7, "maxcor": 30, "maxls": 200, "maxfun": 1e7}
-
-    test_kwargs = copy.deepcopy(default_gsmm_test_kwargs)
-    test_kwargs["method"] = "qEFS"
-    test_kwargs["extend_lambda"] = False
-    test_kwargs["control_lambda"] = 1
-    test_kwargs["max_outer"] = 200
-    test_kwargs["max_inner"] = 500
-    test_kwargs["min_inner"] = 500
-    test_kwargs["seed"] = 0
-    test_kwargs["max_restarts"] = 5
-    test_kwargs["prefit_grad"] = True
-    test_kwargs["sample_hessian"] = False
-    test_kwargs["structured_qefs"] = False
-    test_kwargs["qEFSH"] = "BFGS"
-    test_kwargs["bfgs_options"] = bfgs_opt
-    test_kwargs["sample_hessian_options"] = {"n_samples:": 0}  # Prevent sampling
-
-    model.fit(**test_kwargs)
-
-    def test_GAMedf(self):
-        np.testing.assert_allclose(
-            self.model.edf,
-            18.377187361889852,
-            atol=min(max_atol, 0),
-            rtol=min(max_rtol, 0.1),
-        )
-
-    def test_GAMcoef(self):
-        coef = self.model.coef
-        np.testing.assert_allclose(
-            coef,
-            np.array(
-                [
-                    [7.64905069],
-                    [-0.86673491],
-                    [-0.90094528],
-                    [0.03276751],
-                    [1.15914006],
-                    [1.65315849],
-                    [0.38976786],
-                    [-0.62349091],
-                    [-0.7531447],
-                    [-0.62543635],
-                    [-1.77827109],
-                    [-1.16369955],
-                    [-0.53206949],
-                    [0.30195526],
-                    [0.94751062],
-                    [1.86610313],
-                    [3.08262143],
-                    [4.13731307],
-                    [5.35515618],
-                    [-7.9746717],
-                    [5.31754213],
-                    [6.43841665],
-                    [-1.39549816],
-                    [0.72747751],
-                    [-0.56335123],
-                    [-2.93264959],
-                    [-3.69271431],
-                    [-1.03991244],
-                    [-0.04562291],
-                    [-0.01165826],
-                    [0.00888674],
-                    [0.02409037],
-                    [0.04134725],
-                    [0.06172081],
-                    [0.08447056],
-                    [0.09714901],
-                    [0.10562989],
-                    [0.66701223],
-                ]
-            ),
-            atol=min(max_atol, 0.3),
-            rtol=min(max_rtol, 0.5),
-        )
-
-    def test_GAMlam(self):
-        lam = np.array([p.lam for p in self.model.overall_penalties])
-        np.testing.assert_allclose(
-            lam,
-            np.array(
-                [
-                    0.5660081066190392,
-                    3.6344843285366273,
-                    0.009036189964515981,
-                    2111.2780420530066,
-                ]
-            ),
-            atol=min(max_atol, 0),
-            rtol=min(max_rtol, 3),
-        )
-
-    def test_GAMreml(self):
-        reml = self.model.get_reml()
-        np.testing.assert_allclose(
-            reml, -1073.8484425587437, atol=min(max_atol, 0), rtol=min(max_rtol, 0.1)
-        )
-
-    def test_GAMllk(self):
-        llk = self.model.get_llk(False)
-        np.testing.assert_allclose(
-            llk, -1043.0223032680815, atol=min(max_atol, 0), rtol=min(max_rtol, 0.1)
-        )
-
-    def test_edf1(self):
-        compute_bias_corrected_edf(self.model, overwrite=False)
-        edf1 = np.array([edf1 for edf1 in self.model.term_edf1])
-        np.testing.assert_allclose(
-            edf1,
-            np.array(
-                [
-                    5.31951572924431,
-                    3.6329012604530178,
-                    8.634074326598565,
-                    1.0297773848735796,
-                ]
-            ),
-            atol=min(max_atol, 0),
-            rtol=min(max_rtol, 1.5),
-        )
-
-    def test_ps(self):
-        ps = []
-        for par in range(len(self.model.formulas)):
-            pps, _ = approx_smooth_p_values(self.model, par=par)
-            ps.extend(pps)
-        np.testing.assert_allclose(
-            ps,
-            np.array([0.0047744792490702626, 0.0, 0.0, 0.8676565723545753]),
-            atol=min(max_atol, 0.01),
-            rtol=min(max_rtol, 0.5),
-        )
-
-    def test_TRs(self):
-        Trs = []
-        for par in range(len(self.model.formulas)):
-            _, pTrs = approx_smooth_p_values(self.model, par=par)
-            Trs.extend(pTrs)
-        np.testing.assert_allclose(
-            Trs,
-            np.array(
-                [
-                    17.544251844815605,
-                    97.98996254745872,
-                    346.09962445913857,
-                    0.04502732327983149,
-                ]
-            ),
-            atol=min(max_atol, 0),
-            rtol=min(max_rtol, 1.5),
-        )
-
-
 class Test_PropHaz_hard:
     sim_dat = sim3(
         500, 2, c=1, seed=0, family=PropHaz([0], [0]), binom_offset=0.1, correlate=False
@@ -1880,11 +1701,11 @@ class Test_shared_qefs:
             edf1,
             np.array(
                 [
-                    6.788467635821958,
-                    4.845035260681829,
-                    119.25933972358285,
-                    6.9067432166190805,
-                    2.209226171258083,
+                    6.78846763582194,
+                    4.845035260681827,
+                    119.25933972358332,
+                    6.906743216619086,
+                    2.2092261712580985,
                 ]
             ),
             atol=min(max_atol, 0),
@@ -1898,7 +1719,7 @@ class Test_shared_qefs:
             ps.extend(pps)
         np.testing.assert_allclose(
             ps,
-            np.array([0.0, 0.0, 0.0, 0.1443052734859107]),
+            np.array([0.0, 0.0, 0.0, 0.11668572393893417]),
             atol=min(max_atol, 0.15),
             rtol=min(max_rtol, 0.5),
         )
@@ -1912,10 +1733,10 @@ class Test_shared_qefs:
             Trs,
             np.array(
                 [
-                    53.796589281793814,
-                    2630.3104920856767,
-                    242.58795873779306,
-                    4.620478620568921,
+                    53.796589281794525,
+                    2630.310492085669,
+                    242.58795873779337,
+                    4.620478620568756,
                 ]
             ),
             atol=min(max_atol, 0),


### PR DESCRIPTION
New function ``getCholnH``, which computes the Cholesky of the limited-memory SR1 approximation to the negative Hessian via Cholesky updating/downdating, by treating the quasi-newton update as a low-rank update to ``H_0``, the initial approximation to the Hessian.

MSSM automatically decides whether this is more efficient than simply re-computing the entire Cholesky by forming the limited-memory approximation explicitly.